### PR TITLE
Add patch to enable VPP Vlan tag rewrite

### DIFF
--- a/networking_vpp/agent/server.py
+++ b/networking_vpp/agent/server.py
@@ -193,6 +193,7 @@ class VPPForwarder(object):
                     if_upstream = self.get_vpp_ifidx('%s.%s' % (intf, seg_id))
                     app.logger.debug('Adding upstream trunk interface:%s.%s \
                         to bridge for vlan networking' % (intf, seg_id))
+                self.vpp.set_vlan_tag_rewrite(if_upstream)
             else:
                 raise Exception('network type %s not supported', net_type)
             self.vpp.ifup(if_upstream)


### PR DESCRIPTION
This patch is required to maintain the dot1q Vlan tags with VPP when VLAN
Networking is used. Without this patch, Vlan tags are stripped by VPP.

Signed-off-by: Naveen Joy naveen.joy@gmail.com
